### PR TITLE
Fix: detail component 수정

### DIFF
--- a/src/components/Detail.jsx
+++ b/src/components/Detail.jsx
@@ -49,7 +49,7 @@ const DetailBox = styled.div`
   border-radius: 40px;
   background-color: #f4f6ff;
   width: 800px;
-  gap: 130px;
+  gap: 50px;
   padding: 50px;
   box-shadow: 2px 2px 5px #00000054;
 `;

--- a/src/components/GlobalStyle.jsx
+++ b/src/components/GlobalStyle.jsx
@@ -12,6 +12,7 @@ const GlobalStyle = createGlobalStyle`
         font-family: "TAEBAEKmilkyway";
         font-weight: bold;
         font-style: normal;
+        word-break: break-all ;
     }
 
     body {


### PR DESCRIPTION
상세 페이지에서 내용이 영어일 때 div영역밖으로 튀어나가는 현상때문에
GlobalStyle.jsx에 word-break를 사용하여 해당  현상을 막았습니다.
그 외로 상세 페이지의 상단 TopBox div와 MiddleBox div간의 gap이 너무 커서 수정했습니다.